### PR TITLE
Add a CONTRIBUTING.md to the skeletons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+## Setting up your working environment
+
+Oskel requires OCaml 4.05.0 or higher so you will need a corresponding opam
+switch. OCaml 4.09.0 is a good choice as it makes for a better developper
+experience thanks to improved error messages, amongst other things. You can
+install a 4.09.0 OCaml switch by running:
+```
+opam switch create 4.09.0 ocaml-base-compiler.4.09.0
+```
+
+To clone the project's sources and install both its regular and test
+dependencies run:
+```
+git clone https://github.com:CraigFe/oskel.git
+cd oskel
+opam install -t --deps-only .
+```
+
+From there you can build all of the project's public libraries and executables
+with:
+```
+dune build @install
+```
+and run the test suite with:
+```
+dune runtest
+```
+
+## Generating the examples
+
+The repo contains examples of projects that were generated with `oskel`. When
+modifying the various skeletons you should refresh the examples so that they
+reflect the changes you introduced. You can do so by running:
+```
+make examples
+```
+
+If you add a new project layout, edit [`examples/dune`](examples/dune)
+to generate a new example folder showcasing it:
+```
+    (progn
+     (run oskel --synopsis "Single package in `src`" --kind=library library)
++    (run oskel --synopsis "<describe your layout>" --kind=<new_layout> <new_layout>)
+     (run oskel --synopsis "Binary that depends on a tested library"
+       --kind=binary binary)
+     (run oskel --synopsis "Individual executable" --kind=executable
+       executable)))))
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,15 @@
 ## Setting up your working environment
 
 Oskel requires OCaml 4.05.0 or higher so you will need a corresponding opam
-switch.
-You can install a switch with the latest OCaml version by running:
+switch. You can install a switch with the latest OCaml version by running:
+
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```
 
 To clone the project's sources and install both its regular and test
 dependencies run:
+
 ```
 git clone https://github.com:CraigFe/oskel.git
 cd oskel
@@ -17,10 +18,13 @@ opam install -t --deps-only .
 
 From there you can build all of the project's public libraries and executables
 with:
+
 ```
 dune build @install
 ```
+
 and run the test suite with:
+
 ```
 dune runtest
 ```
@@ -30,13 +34,15 @@ dune runtest
 The repo contains examples of projects that were generated with `oskel`. When
 modifying the various skeletons you should refresh the examples so that they
 reflect the changes you introduced. You can do so by running:
+
 ```
 make examples
 ```
 
-If you add a new project layout, edit [`examples/dune`](examples/dune)
-to generate a new example folder showcasing it:
-```
+If you add a new project layout, edit [`examples/dune`](examples/dune) to
+generate a new example folder showcasing it:
+
+```diff
     (progn
      (run oskel --synopsis "Single package in `src`" --kind=library library)
 +    (run oskel --synopsis "<describe your layout>" --kind=<new_layout> <new_layout>)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,8 @@
 ## Setting up your working environment
 
 Oskel requires OCaml 4.05.0 or higher so you will need a corresponding opam
-switch. OCaml 4.09.0 is a good choice as it makes for a better developper
-experience thanks to improved error messages, amongst other things. You can
-install a 4.09.0 OCaml switch by running:
+switch.
+You can install a switch with the latest OCaml version by running:
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+MD_FILES = *.md examples/**/*.md
 
 .PHONY: examples
 examples:
@@ -5,3 +6,13 @@ examples:
 	dune build @examples
 	find examples/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf '{}' \;
 	find _build/default/examples -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' -exec cp -rf '{}' examples/ \;
+
+.PHONY: lint
+lint:
+	prettier --check $(MD_FILES)
+	dune build @fmt
+
+.PHONY: format
+format:
+	prettier --check $(MD_FILES)
+	dune build --auto-promote @fmt

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ the project structure.
 opam install oskel
 ```
 
+If you want to contribute to the project, please read
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Configuration
 
 `oskel` is very configurable (see [`oskel --help`](./oskel-help.txt) for

--- a/examples/binary/CONTRIBUTING.md
+++ b/examples/binary/CONTRIBUTING.md
@@ -28,3 +28,6 @@ and run the test suite with:
 ```
 dune runtest
 ```
+
+If the test suite fails, it may propose a diff to fix the issue. You may accept
+the proposed diff with `dune promote`.

--- a/examples/binary/CONTRIBUTING.md
+++ b/examples/binary/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 ## Setting up your working environment
 
-binary requires OCaml 4.09.0 or higher so you will need a corresponding opam switch
-which you can install by running:
+binary requires OCaml 4.09.0 or higher so you will need a corresponding opam
+switch. OCaml 4.09.0 is a good choice as it makes for a better developper
+experience thanks to improved error messages, amongst other things. You can
+install a 4.09.0 OCaml switch by running:
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```

--- a/examples/binary/CONTRIBUTING.md
+++ b/examples/binary/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+## Setting up your working environment
+
+binary requires OCaml 4.09.0 or higher so you will need a corresponding opam switch
+which you can install by running:
+```
+opam switch create 4.09.0 ocaml-base-compiler.4.09.0
+```
+
+To clone the project's sources and install both its regular and test
+dependencies run:
+```
+git clone https://github.com:JoeBloggs/binary.git
+cd binary
+opam install -t --deps-only .
+```
+
+From there you can build all of the project's public libraries and executables
+with:
+```
+dune build @install
+```
+and run the test suite with:
+```
+dune runtest
+```

--- a/examples/binary/CONTRIBUTING.md
+++ b/examples/binary/CONTRIBUTING.md
@@ -1,14 +1,15 @@
 ## Setting up your working environment
 
 binary requires OCaml 4.09.0 or higher so you will need a corresponding opam
-switch.
-You can install a switch with the latest OCaml version by running:
+switch. You can install a switch with the latest OCaml version by running:
+
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```
 
 To clone the project's sources and install both its regular and test
 dependencies run:
+
 ```
 git clone https://github.com:JoeBloggs/binary.git
 cd binary
@@ -17,10 +18,13 @@ opam install -t --deps-only .
 
 From there you can build all of the project's public libraries and executables
 with:
+
 ```
 dune build @install
 ```
+
 and run the test suite with:
+
 ```
 dune runtest
 ```

--- a/examples/binary/CONTRIBUTING.md
+++ b/examples/binary/CONTRIBUTING.md
@@ -1,9 +1,8 @@
 ## Setting up your working environment
 
 binary requires OCaml 4.09.0 or higher so you will need a corresponding opam
-switch. OCaml 4.09.0 is a good choice as it makes for a better developper
-experience thanks to improved error messages, amongst other things. You can
-install a 4.09.0 OCaml switch by running:
+switch.
+You can install a switch with the latest OCaml version by running:
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```

--- a/examples/binary/README.md
+++ b/examples/binary/README.md
@@ -8,3 +8,6 @@ Binary that depends on a tested library
 opam pin add --yes https://github.com/JoeBloggs/binary.git
 opam install binary
 ```
+
+If you want to contribute to the project, please read
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/examples/library/CONTRIBUTING.md
+++ b/examples/library/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 ## Setting up your working environment
 
-library requires OCaml 4.09.0 or higher so you will need a corresponding opam switch
-which you can install by running:
+library requires OCaml 4.09.0 or higher so you will need a corresponding opam
+switch. OCaml 4.09.0 is a good choice as it makes for a better developper
+experience thanks to improved error messages, amongst other things. You can
+install a 4.09.0 OCaml switch by running:
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```

--- a/examples/library/CONTRIBUTING.md
+++ b/examples/library/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+## Setting up your working environment
+
+library requires OCaml 4.09.0 or higher so you will need a corresponding opam switch
+which you can install by running:
+```
+opam switch create 4.09.0 ocaml-base-compiler.4.09.0
+```
+
+To clone the project's sources and install both its regular and test
+dependencies run:
+```
+git clone https://github.com:JoeBloggs/library.git
+cd library
+opam install -t --deps-only .
+```
+
+From there you can build all of the project's public libraries and executables
+with:
+```
+dune build @install
+```
+and run the test suite with:
+```
+dune runtest
+```

--- a/examples/library/CONTRIBUTING.md
+++ b/examples/library/CONTRIBUTING.md
@@ -1,9 +1,8 @@
 ## Setting up your working environment
 
 library requires OCaml 4.09.0 or higher so you will need a corresponding opam
-switch. OCaml 4.09.0 is a good choice as it makes for a better developper
-experience thanks to improved error messages, amongst other things. You can
-install a 4.09.0 OCaml switch by running:
+switch.
+You can install a switch with the latest OCaml version by running:
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```

--- a/examples/library/CONTRIBUTING.md
+++ b/examples/library/CONTRIBUTING.md
@@ -1,14 +1,15 @@
 ## Setting up your working environment
 
 library requires OCaml 4.09.0 or higher so you will need a corresponding opam
-switch.
-You can install a switch with the latest OCaml version by running:
+switch. You can install a switch with the latest OCaml version by running:
+
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```
 
 To clone the project's sources and install both its regular and test
 dependencies run:
+
 ```
 git clone https://github.com:JoeBloggs/library.git
 cd library
@@ -17,10 +18,13 @@ opam install -t --deps-only .
 
 From there you can build all of the project's public libraries and executables
 with:
+
 ```
 dune build @install
 ```
+
 and run the test suite with:
+
 ```
 dune runtest
 ```

--- a/examples/library/README.md
+++ b/examples/library/README.md
@@ -8,3 +8,6 @@ Single package in `src`
 opam pin add --yes https://github.com/JoeBloggs/library.git
 opam install library
 ```
+
+If you want to contribute to the project, please read
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/lib/contents.ml
+++ b/lib/contents.ml
@@ -134,17 +134,15 @@ let contributing config ppf =
     {|## Setting up your working environment
 
 %s requires OCaml %s or higher so you will need a corresponding opam
-switch.
-You can install a switch with the latest OCaml version by running:
+switch. You can install a switch with the latest OCaml version by running:
+
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```
-|}
-    config.project config.version_ocaml;
-  Fmt.pf ppf
-    {|
+
 To clone the project's sources and install both its regular and test
 dependencies run:
+
 ```
 git clone https://github.com:%s/%s.git
 cd %s
@@ -153,15 +151,18 @@ opam install -t --deps-only .
 
 From there you can build all of the project's public libraries and executables
 with:
+
 ```
 dune build @install
 ```
+
 and run the test suite with:
+
 ```
 dune runtest
 ```|}
-    config.github_organisation config.project
-    config.project
+    config.project config.version_ocaml config.github_organisation
+    config.project config.project
 
 let readme_ppx = readme
 

--- a/lib/contents.ml
+++ b/lib/contents.ml
@@ -134,9 +134,8 @@ let contributing config ppf =
     {|## Setting up your working environment
 
 %s requires OCaml %s or higher so you will need a corresponding opam
-switch. OCaml 4.09.0 is a good choice as it makes for a better developper
-experience thanks to improved error messages, amongst other things. You can
-install a 4.09.0 OCaml switch by running:
+switch.
+You can install a switch with the latest OCaml version by running:
 ```
 opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```

--- a/lib/contents.ml
+++ b/lib/contents.ml
@@ -122,9 +122,46 @@ let readme config ppf =
 ```
 opam pin add --yes https://github.com/%s/%s.git
 opam install %s
-```|}
+```
+
+If you want to contribute to the project, please read
+[CONTRIBUTING.md](CONTRIBUTING.md).|}
     config.project config.project_synopsis config.github_organisation
     config.project config.project
+
+let contributing config ppf =
+  Fmt.pf ppf
+    {|## Setting up your working environment
+
+%s requires OCaml %s or higher so you will need a corresponding opam switch
+which you can install by running:
+```
+opam switch create %s ocaml-base-compiler.%s
+```
+|}
+    config.project config.version_ocaml
+    config.version_ocaml config.version_ocaml;
+  Fmt.pf ppf
+    {|
+To clone the project's sources and install both its regular and test
+dependencies run:
+```
+git clone https://github.com:%s/%s.git
+cd %s
+opam install -t --deps-only .
+```
+
+From there you can build all of the project's public libraries and executables
+with:
+```
+dune build @install
+```
+and run the test suite with:
+```
+dune runtest
+```|}
+    config.github_organisation config.project
+    config.project
 
 let readme_ppx = readme
 

--- a/lib/contents.ml
+++ b/lib/contents.ml
@@ -133,14 +133,15 @@ let contributing config ppf =
   Fmt.pf ppf
     {|## Setting up your working environment
 
-%s requires OCaml %s or higher so you will need a corresponding opam switch
-which you can install by running:
+%s requires OCaml %s or higher so you will need a corresponding opam
+switch. OCaml 4.09.0 is a good choice as it makes for a better developper
+experience thanks to improved error messages, amongst other things. You can
+install a 4.09.0 OCaml switch by running:
 ```
-opam switch create %s ocaml-base-compiler.%s
+opam switch create 4.09.0 ocaml-base-compiler.4.09.0
 ```
 |}
-    config.project config.version_ocaml
-    config.version_ocaml config.version_ocaml;
+    config.project config.version_ocaml;
   Fmt.pf ppf
     {|
 To clone the project's sources and install both its regular and test

--- a/lib/contents.ml
+++ b/lib/contents.ml
@@ -129,7 +129,7 @@ If you want to contribute to the project, please read
     config.project config.project_synopsis config.github_organisation
     config.project config.project
 
-let contributing config ppf =
+let contributing ?promote config ppf =
   Fmt.pf ppf
     {|## Setting up your working environment
 
@@ -162,7 +162,15 @@ and run the test suite with:
 dune runtest
 ```|}
     config.project config.version_ocaml config.github_organisation
-    config.project config.project
+    config.project config.project;
+  match promote with
+  | Some () ->
+      Fmt.pf ppf
+        {|
+
+If the test suite fails, it may propose a diff to fix the issue. You may accept
+the proposed diff with `dune promote`.|}
+  | None -> ()
 
 let readme_ppx = readme
 

--- a/lib/contents.mli
+++ b/lib/contents.mli
@@ -27,7 +27,7 @@ val gitignore : file_printer
 
 val readme : file_printer
 
-val contributing : file_printer
+val contributing : ?promote:unit -> file_printer
 
 val readme_ppx : file_printer
 

--- a/lib/contents.mli
+++ b/lib/contents.mli
@@ -27,6 +27,8 @@ val gitignore : file_printer
 
 val readme : file_printer
 
+val contributing : file_printer
+
 val readme_ppx : file_printer
 
 val changes : file_printer

--- a/lib/layouts.ml
+++ b/lib/layouts.ml
@@ -72,6 +72,7 @@ let library (config : Config.t) =
         File ("dune-project", Dune_project.package config);
         File ("LICENSE", license config);
         File ("README.md", readme config);
+        File ("CONTRIBUTING.md", contributing config);
         File ("CHANGES.md", changes config);
         (* Empty structure here only for pretty-printing to the user  *)
         File (config.project ^ ".opam", fun _ -> ());
@@ -132,6 +133,7 @@ let binary (config : Config.t) =
         File ("dune-project", Dune_project.package config);
         File ("LICENSE", license config);
         File ("README.md", readme config);
+        File ("CONTRIBUTING.md", contributing config);
         File ("CHANGES.md", changes config);
         File (config.project ^ "-help.txt", bin_help_txt config);
         (* Empty structure here only for pretty-printing to the user  *)
@@ -186,6 +188,7 @@ let _ppx_deriver config =
         File ("dune-project", Dune.library config);
         File ("LICENSE", license config);
         File ("README.md", readme_ppx config);
+        File ("CONTRIBUTING.md", contributing config);
         File ("CHANGES.md", changes config);
         (* Empty structure here only for pretty-printing to the user  *)
         File (config.project ^ ".opam", fun _ -> ());

--- a/lib/layouts.ml
+++ b/lib/layouts.ml
@@ -133,7 +133,7 @@ let binary (config : Config.t) =
         File ("dune-project", Dune_project.package config);
         File ("LICENSE", license config);
         File ("README.md", readme config);
-        File ("CONTRIBUTING.md", contributing config);
+        File ("CONTRIBUTING.md", contributing ~promote:() config);
         File ("CHANGES.md", changes config);
         File (config.project ^ "-help.txt", bin_help_txt config);
         (* Empty structure here only for pretty-printing to the user  *)

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  proseWrap: "always"
+};


### PR DESCRIPTION
As we discussed offline, I added a CONTRIBUTING.md file to the skeletons.

It contains information relevant to crating an opam switch with a matching ocaml version, cloning the project, installing the dependencies, building and running the tests.

We could control its presence through configuration eventually but I wanted to hear your thought on this first.

I also updated the examples and added a `CONTRIBUTING.md` to the repo with a bonus section about updating the examples!

Let me know what you think!