### PR TITLE
Add --non-interactive flag for disabling user interactions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 - Add a `CONTRIBUTING.md` file to the skeletons. (@NathanReb, #5)
 - Read name and email from `git config` if not set by the CLI (@CraigFe, #6)
-- Allow various project options to be set in an interactive mode (@CraigFe, #7)
+- Allow various project options to be set in an interactive mode (@CraigFe, #7 #9)
 - Allow customising the project's initial release version (@CraigFe, #8)
 
 # 0.1.0

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -13,14 +13,14 @@ let ( >>? ) x f = match x with Some s -> Some s | None -> f ()
 let run name project_kind project_synopsis maintainer_fullname maintainer_email
     github_organisation initial_version license dependencies version_dune
     version_ocaml version_opam version_ocamlformat ocamlformat_options dry_run
-    git_repo current_year () =
+    non_interactive git_repo current_year () =
   let maintainer_fullname = maintainer_fullname >>? git_user_name in
   let maintainer_email = maintainer_email >>? git_email in
   Oskel.run ?name ~project_kind ?project_synopsis ?maintainer_fullname
     ?maintainer_email ?github_organisation ?initial_version ~license
     ~dependencies ~version_dune ~version_ocaml ~version_opam
-    ~version_ocamlformat ~ocamlformat_options ~dry_run ~git_repo ?current_year
-    ()
+    ~version_ocamlformat ~ocamlformat_options ~dry_run ~non_interactive
+    ~git_repo ?current_year ()
 
 open Cmdliner
 
@@ -126,6 +126,10 @@ let dry_run =
   let doc = "Simulate the command, but don't actually perform any changes." in
   Arg.(value & flag & info [ "dry-run" ] ~doc)
 
+let non_interactive =
+  let doc = "Do not show interactive prompts." in
+  Arg.(value & flag & info [ "non-interactive" ] ~doc)
+
 let git_repo =
   let doc = "Don't generate a git repository for the project." in
   let env = Arg.env_var "DISABLE_GIT" in
@@ -167,6 +171,7 @@ let term =
       $ version_ocamlformat
       $ ocamlformat_options
       $ dry_run
+      $ non_interactive
       $ git_repo
       $ current_year
       $ setup_log,

--- a/examples/dune
+++ b/examples/dune
@@ -5,11 +5,12 @@
   (chdir
    %{project_root}/examples
    (progn
-    (run oskel --synopsis "Single package in `src`" --kind=library library)
-    (run oskel --synopsis "Binary that depends on a tested library"
-      --kind=binary binary)
-    (run oskel --synopsis "Individual executable" --kind=executable
-      executable)))))
+    (run oskel --non-interactive --synopsis "Single package in `src`"
+      --kind=library library)
+    (run oskel --non-interactive --synopsis
+      "Binary that depends on a tested library" --kind=binary binary)
+    (run oskel --non-interactive --synopsis "Individual executable"
+      --kind=executable executable)))))
 
 (env
  (_

--- a/lib/oskel.ml
+++ b/lib/oskel.ml
@@ -16,21 +16,24 @@ let main ~dry_run ~project_kind config =
 let get_current_year () =
   Unix.time () |> Unix.localtime |> fun t -> t.Unix.tm_year + 1900
 
-let ask ?default prompt = function
+let ask ~non_interactive ?default prompt = function
   | Some s -> Ok s
   | None -> (
-      let pp_default =
-        Fmt.(option (string |> using (fun s -> " (" ^ s ^ ")")))
-      in
-      Fmt.pr "%a %s%a: %!"
-        Fmt.(styled `Faint string)
-        "question" prompt pp_default default;
-      try
-        Sys.catch_break true;
-        let s = read_line () in
-        Sys.catch_break false;
-        match (s, default) with "", Some default -> Ok default | _ -> Ok s
-      with Sys.Break -> Error (`Msg "Cancelled") )
+      if non_interactive then
+        Error (`Msg (Fmt.str "Must set '%s' or enable interactive mode" prompt))
+      else
+        let pp_default =
+          Fmt.(option (string |> using (fun s -> " (" ^ s ^ ")")))
+        in
+        Fmt.pr "%a %s%a: %!"
+          Fmt.(styled `Faint string)
+          "question" prompt pp_default default;
+        try
+          Sys.catch_break true;
+          let s = read_line () in
+          Sys.catch_break false;
+          match (s, default) with "", Some default -> Ok default | _ -> Ok s
+        with Sys.Break -> Error (`Msg "Cancelled") )
 
 let assert_ok = function
   | Ok x -> x
@@ -47,23 +50,29 @@ let adjective_animal () =
 let run ~project_kind ?name ?project_synopsis ?maintainer_fullname
     ?maintainer_email ?github_organisation ?initial_version ~license
     ~dependencies ~version_dune ~version_ocaml ~version_opam
-    ~version_ocamlformat ~ocamlformat_options ~dry_run ~git_repo
-    ?(current_year = get_current_year ()) () =
+    ~version_ocamlformat ~ocamlformat_options ~dry_run ~non_interactive
+    ~git_repo ?(current_year = get_current_year ()) () =
   Logs.app (fun m -> m "%a" Fmt.(styled `Bold string) "oskel v%%VERSION%%");
   Random.self_init ();
   let name =
-    ask ~default:(adjective_animal ()) "name" name
+    ask ~non_interactive ~default:(adjective_animal ()) "name" name
     >>= Validate.project
     |> assert_ok
   in
-  let maintainer_fullname = ask "author" maintainer_fullname |> assert_ok in
-  let maintainer_email = ask "email" maintainer_email |> assert_ok in
-  let github_organisation =
-    ask "GitHub name" github_organisation |> assert_ok
+  let maintainer_fullname =
+    ask ~non_interactive "author" maintainer_fullname |> assert_ok
   in
-  let project_synopsis = ask "synopsis" project_synopsis |> assert_ok in
+  let maintainer_email =
+    ask ~non_interactive "email" maintainer_email |> assert_ok
+  in
+  let github_organisation =
+    ask ~non_interactive "GitHub name" github_organisation |> assert_ok
+  in
+  let project_synopsis =
+    ask ~non_interactive "synopsis" project_synopsis |> assert_ok
+  in
   let initial_version =
-    ask ~default:"0.1.0" "version" initial_version |> assert_ok
+    ask ~non_interactive ~default:"0.1.0" "version" initial_version |> assert_ok
   in
   main ~project_kind ~dry_run
     {

--- a/lib/oskel.mli
+++ b/lib/oskel.mli
@@ -18,6 +18,7 @@ val run :
   version_ocamlformat:string ->
   ocamlformat_options:(string * string) list ->
   dry_run:bool ->
+  non_interactive:bool ->
   git_repo:bool ->
   ?current_year:int ->
   unit ->

--- a/oskel-help.txt
+++ b/oskel-help.txt
@@ -48,6 +48,9 @@ OPTIONS
            License to add to the project. One of one of `apache2', `bsd2',
            `bsd3', `isc' or `mit'.
 
+       --non-interactive
+           Do not show interactive prompts.
+
        --ocamlformat-options=VAL (absent OSKEL_OCAMLFORMAT_OPTIONS env)
            Options to add to the .ocamlformat file, as a comma-separated list
            of key-value pairs. (e.g.


### PR DESCRIPTION
This is used to prevent Oskel from hanging when invoked incorrectly from within
the examples.