### PR TITLE
Add `:with-test` to test dependencies

### DIFF
--- a/examples/binary/.ocamlformat
+++ b/examples/binary/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.12
+version = [m0.19.0[0m

--- a/examples/binary/CONTRIBUTING.md
+++ b/examples/binary/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Setting up your working environment
 
-binary requires OCaml 4.09.0 or higher so you will need a corresponding opam
+binary requires OCaml [m4.14.0[0m or higher so you will need a corresponding opam
 switch. You can install a switch with the latest OCaml version by running:
 
 ```

--- a/examples/binary/dune-project
+++ b/examples/binary/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune [01;35m2.9.1[0m)
 (name binary)
 (implicit_transitive_deps false)
 

--- a/examples/binary/dune-project
+++ b/examples/binary/dune-project
@@ -14,4 +14,4 @@
 Binary that depends on a tested library
 ")
  (documentation https://JoeBloggs.github.io/binary/)
- (depends alcotest fmt logs))
+ (depends (alcotest :with-test) fmt logs))

--- a/examples/binary/lib/dune
+++ b/examples/binary/lib/dune
@@ -1,3 +1,4 @@
 (library
  (name binary)
+ (public_name binary)
  (libraries logs))

--- a/examples/executable/dune-project
+++ b/examples/executable/dune-project
@@ -1,1 +1,1 @@
-(lang dune 2.0)
+(lang dune [01;35m2.9.1[0m)

--- a/examples/library/.ocamlformat
+++ b/examples/library/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.12
+version = [m0.19.0[0m

--- a/examples/library/CONTRIBUTING.md
+++ b/examples/library/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Setting up your working environment
 
-library requires OCaml 4.09.0 or higher so you will need a corresponding opam
+library requires OCaml [m4.14.0[0m or higher so you will need a corresponding opam
 switch. You can install a switch with the latest OCaml version by running:
 
 ```

--- a/examples/library/dune-project
+++ b/examples/library/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune [01;35m2.9.1[0m)
 (name library)
 (implicit_transitive_deps false)
 

--- a/examples/library/dune-project
+++ b/examples/library/dune-project
@@ -14,4 +14,4 @@
 Single package in `src`
 ")
  (documentation https://JoeBloggs.github.io/library/)
- (depends alcotest fmt logs))
+ (depends (alcotest :with-test) fmt logs))

--- a/examples/library/src/dune
+++ b/examples/library/src/dune
@@ -1,3 +1,4 @@
 (library
  (name library)
+ (public_name library)
  (libraries logs))

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -7,6 +7,11 @@ type versions = {
   ocamlformat : string;
 }
 
+type dependency = {
+  dep_name : string;
+  dep_filter : string option;  (** For example, ["with-test"]. *)
+}
+
 type t = {
   name : string;
   project_synopsis : string;
@@ -15,7 +20,7 @@ type t = {
   github_organisation : string;
   initial_version : string;
   license : License.t;
-  dependencies : string list;
+  dependencies : dependency list;
   versions : versions;
   ocamlformat_options : (string * string) list;
   current_year : int;

--- a/lib/layouts.ml
+++ b/lib/layouts.ml
@@ -152,7 +152,7 @@ let binary = { layout = binary; post_init = [] }
 let executable (config : Config.t) =
   let name = config.name in
   let toplevel_file = Utils.Utils_naming.file_of_project name in
-  let libraries = config.dependencies in
+  let libraries = List.map (fun d -> d.Config.dep_name) config.dependencies in
   let open Contents in
   Folder
     ( config.name,

--- a/lib/oskel.ml
+++ b/lib/oskel.ml
@@ -180,6 +180,11 @@ let run ~project_kind ?name ?project_synopsis ~maintainer_fullname
              if !progress_bar_active then Printf.printf "\r\n%!";
              return ())
     and+ c = config >* progress in
+    let dependencies =
+      List.map
+        (fun dep_name -> { Config.dep_name; dep_filter = None })
+        dependencies
+    in
     let versions =
       versions
       |> function


### PR DESCRIPTION
In the `dune-project` file, `alcotest` was declared as a normal dependency.
Also used the same logic when generating the opam file.